### PR TITLE
Add a option to allow multiple instances on the same device

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -237,14 +237,19 @@ impl PartyApp {
                     {
                         continue;
                     }
-                    if self.is_device_in_any_instance(i) {
+                    if !self.options.allow_multiple_instances_on_same_device 
+                        && self.is_device_in_any_instance(i) {
                         continue;
                     }
 
                     match self.instance_add_dev {
                         Some(inst) => {
-                            self.instance_add_dev = None;
-                            self.instances[inst].devices.push(i);
+                            // Add the device in the instance only if it's not already there
+                            if !self.is_device_in_instance(inst, i) {
+                                self.instance_add_dev = None;
+                                self.instances[inst].devices.push(i);
+                            }
+                            else { continue; }
                         }
                         None => {
                             self.instances.push(Instance {
@@ -284,11 +289,18 @@ impl PartyApp {
         }
     }
 
-    fn is_device_in_any_instance(&mut self, dev: usize) -> bool {
+    fn is_device_in_any_instance(&self, dev: usize) -> bool {
         for instance in &self.instances {
             if instance.devices.contains(&dev) {
                 return true;
             }
+        }
+        false
+    }
+
+    fn is_device_in_instance(&self, instance_index: usize, dev: usize) -> bool {
+        if self.instances[instance_index].devices.contains(&dev) {
+            return true;
         }
         false
     }
@@ -303,10 +315,35 @@ impl PartyApp {
         }
         None
     }
+    
+    fn find_device_in_instance_from_end(&mut self, dev: usize) -> Option<(usize, usize)> {
+        for (i, instance) in self.instances.iter().enumerate().rev() {
+            for (d, device) in instance.devices.iter().enumerate() {
+                if device == &dev {
+                    return Some((i, d));
+                }
+            }
+        }
+        None
+    }
 
     pub fn remove_device(&mut self, dev: usize) {
-        if let Some((instance_index, device_index)) = self.find_device_in_instance(dev) {
+        if let Some((instance_index, device_index)) = self.find_device_in_instance_from_end(dev) {
             self.instances[instance_index].devices.remove(device_index);
+            if self.instances[instance_index].devices.is_empty() {
+                self.instances.remove(instance_index);
+            }
+        }
+    }
+    
+    pub fn remove_device_instance(&mut self, instance_index: usize, dev: usize) {
+        let device_index = self.instances[instance_index].devices
+            .iter()
+            .position(|device| device == &dev);
+
+        if let Some(d) = device_index {
+            self.instances[instance_index].devices.remove(d);
+
             if self.instances[instance_index].devices.is_empty() {
                 self.instances.remove(instance_index);
             }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -25,6 +25,8 @@ pub struct PartyConfig {
     #[serde(default)]
     pub vertical_two_player: bool,
     pub pad_filter_type: PadFilterType,
+    #[serde(default)]
+    pub allow_multiple_instances_on_same_device: bool,
 }
 
 impl Default for PartyConfig {
@@ -39,6 +41,7 @@ impl Default for PartyConfig {
             proton_separate_pfxs: false,
             vertical_two_player: false,
             pad_filter_type: PadFilterType::NoSteamInput,
+            allow_multiple_instances_on_same_device: false,
         }
     }
 }

--- a/src/app/gui_pages.rs
+++ b/src/app/gui_pages.rs
@@ -207,7 +207,7 @@ impl PartyApp {
 
         ui.separator();
 
-        let mut devices_to_remove = Vec::new();
+        let mut devices_to_remove: Vec<(usize,usize)> = Vec::new();
         for (i, instance) in &mut self.instances.iter_mut().enumerate() {
             ui.horizontal(|ui| {
                 ui.label(format!("Instance {}", i + 1));
@@ -248,14 +248,14 @@ impl PartyApp {
                     ui.label("  ");
                     ui.label(dev_text);
                     if ui.button("🗑").clicked() {
-                        devices_to_remove.push(dev);
+                        devices_to_remove.push((i, dev));
                     }
                 });
             }
         }
 
-        for d in devices_to_remove {
-            self.remove_device(d);
+        for (i, d) in devices_to_remove {
+            self.remove_device_instance(i, d);
         }
 
         if self.instances.len() > 0 {
@@ -347,6 +347,14 @@ impl PartyApp {
         );
         if proton_separate_pfxs_check.hovered() {
             self.infotext = "Runs each instance in its own Proton prefix. If unsure, leave this unchecked. This option will take up more space on the disk, but may also help with certain Proton-related issues such as only one instance of a game starting.".to_string();
+        }
+        
+        let allow_multiple_instances_on_same_device_check = ui.checkbox(
+            &mut self.options.allow_multiple_instances_on_same_device,
+            "Allow multiple instances on the same device",
+        );
+        if allow_multiple_instances_on_same_device_check.hovered() {
+            self.infotext = "Allow multiple instances on the same device. This can be useful for testing or when one person wants to control multiple instances.".to_string();
         }
 
         ui.separator();


### PR DESCRIPTION
Hello, I add this option because I think it's useful for testing or for fun?
I'm working on a branch to add the option to use Sway instead of KWin and I wanted to try to play with 64 instances so that's why?

For the PR, I had to fix some issues like: deleting the latest instance of the controller instead of the first one when deleting with button device, or the deleting clickable button deleting the device of the wrong instance, or prevent having the same devices in the same instance.

I Hope it looks not too bad. It's the first time I'm coding in rust.

Also when there is too many instances it goes out of the window, so there should be scrollable thing I guess? Didn't do it in the PR.