### PR TITLE
Add handler option for custom pause between instance starts

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -28,6 +28,7 @@ pub struct Handler {
     pub copy_instead_paths: Vec<String>,
     pub remove_paths: Vec<String>,
     pub dll_overrides: Vec<String>,
+    pub pause_between_starts: Option<f64>,
 
     pub path_goldberg: String,
     pub steam_appid: Option<String>,
@@ -112,6 +113,8 @@ impl Handler {
                         .collect()
                 })
                 .unwrap_or_default(),
+            pause_between_starts: json["game.pause_between_starts"].as_f64(),
+
 
             path_goldberg: json["steam.api_path"]
                 .as_str()

--- a/src/launch.rs
+++ b/src/launch.rs
@@ -300,10 +300,11 @@ pub fn launch_cmd(
         if i < instances.len() - 1 {
             // Proton games need a ~5 second buffer in-between launches
             // TODO: investigate why this is
-            match win {
-                true => cmd.push_str("& sleep 6; "),
-                false => cmd.push_str("& sleep 0.01; "),
-            }
+            let pause_duration = match game {
+                HandlerRef(h) => h.pause_between_starts.unwrap_or(if win { 6.0 } else { 0.01 }),
+                ExecRef(_) => if win { 6.0 } else { 0.01 },
+            };
+            cmd.push_str(&format!("& sleep {pause_duration}; "));
         }
     }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/a915d89c-4179-4a3a-9ff8-3648cdc502c8

This add the option `game.pause_between_starts` in the handlers json.
Example: `"game.pause_between_starts": 5`

It could be used for example in Celeste handler (#58).

Hope the PR looks okay!